### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Modern PHP frameworks are often pretty fat, and too large to put into a single r
 
 Without the extra weight, it is very efficient and fast. On an average machine it should be able to handle thousands of request per second, if not more.
 
-And the minimalistic design also helps to make the learning curve more confortable to newcomers, rookie engineers, and even those just want to learn the right way to do PHP.
+And the minimalistic design also helps to make the learning curve more comfortable to newcomers, rookie engineers, and even those just want to learn the right way to do PHP.
 
 Because AF use the least language feature as possible, it is also possible to adapt it to an older enviroment, makes it easier to modernize legacy product.
 


### PR DESCRIPTION
@CQD, I've corrected a typographical error in the documentation of the [AF](https://github.com/CQD/AF) project. Specifically, I've changed confortable to comfortable. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
